### PR TITLE
Update core.js to use `export default Quill` instead of `module.exports = Quill`

### DIFF
--- a/core.js
+++ b/core.js
@@ -33,4 +33,4 @@ Quill.register({
 Parchment.register(Block, Break, Cursor, Inline, Scroll, TextBlot);
 
 
-module.exports = Quill;
+export default Quill;


### PR DESCRIPTION
In Webpack 2, I get an error `Uncaught TypeError: Cannot assign to read only property 'exports' of object '#<Object>' at Object.eval (core.js:51)` because Quill uses a mix of ES6 `import` and CommonJS `module.exports`. I can't find any plugin for Babel or Webpack to properly handle this case to avoid the error. But if I change core.js to use `export default`, everything works well.

I'm not sure if this change would break anything Quill is trying to do, but in general it is weird that core.js is mixing ES6 and CommonJS.